### PR TITLE
fix(fetch): improve the description for fetch tool

### DIFF
--- a/servlets/fetch/src/lib.rs
+++ b/servlets/fetch/src/lib.rs
@@ -101,7 +101,7 @@ pub(crate) fn describe() -> Result<ToolDescription, Error> {
     Ok(ToolDescription {
         name: "fetch".into(),
         description:
-            "Fetches the contents of a URL and returns it's contents converted to markdown".into(),
+            "Enables to open and access arbitrary URLs. Fetches the contents of a URL and returns its contents converted to markdown".into(),
         input_schema: schema,
     })
 }


### PR DESCRIPTION
We explicitly add the note "Enables to open and access arbitrary URLs." to instruct the LLM that the tool can be used to "open" URLs. Otherwise it won't know that fetch and open are synonyms in this context