### PR TITLE
fix: Makefile was missing npm install step

### DIFF
--- a/simulations/describe-output/Makefile
+++ b/simulations/describe-output/Makefile
@@ -1,4 +1,5 @@
 build:
+	npm ci
 	npm run build
 
 test: build


### PR DESCRIPTION
A-ha – I think the `Makefile` had a `npm run build` step, but `npm` doesn't automatically run `install` when executing `npm run` scripts.