### PR TITLE
feat(bluesky): allow https:// URI also in getThread

### DIFF
--- a/servlets/bluesky/main.go
+++ b/servlets/bluesky/main.go
@@ -25,6 +25,8 @@ func Call(input CallToolRequest) (CallToolResult, error) {
 		return reply(input.Params.Arguments.(map[string]any))
 	case "latest_mentions":
 		return latestMentions(input.Params.Arguments.(map[string]any))
+	case "search":
+		return search(input.Params.Arguments.(map[string]any))
 	case "get_thread":
 		return getThread(input.Params.Arguments.(map[string]any))
 	default:

--- a/servlets/bluesky/post.go
+++ b/servlets/bluesky/post.go
@@ -71,11 +71,12 @@ func getThread(args map[string]any) (CallToolResult, error) {
 		return callToolError(fmt.Sprintf("failed to login: %s", err.Error())), nil
 	}
 	uri, ok := args["uri"].(string)
-	// allow web URIs and conver them to AT URIs
-	uri = webUriToAT(uri)
 	if !ok {
 		return callToolError("missing uri"), nil
 	}
+	// allow web URIs and conver them to AT URIs
+	uri = webUriToAT(uri)
+	pdk.Log(pdk.LogInfo, fmt.Sprintf("uri: %s", uri))
 	depth, ok := args["depth"].(int)
 	if !ok {
 		depth = 6

--- a/servlets/bluesky/post.go
+++ b/servlets/bluesky/post.go
@@ -71,6 +71,8 @@ func getThread(args map[string]any) (CallToolResult, error) {
 		return callToolError(fmt.Sprintf("failed to login: %s", err.Error())), nil
 	}
 	uri, ok := args["uri"].(string)
+	// allow web URIs and conver them to AT URIs
+	uri = webUriToAT(uri)
 	if !ok {
 		return callToolError("missing uri"), nil
 	}

--- a/servlets/bluesky/reply.go
+++ b/servlets/bluesky/reply.go
@@ -37,11 +37,11 @@ func reply(args map[string]any) (CallToolResult, error) {
 // - https://bsky.app/profile/<DID>/post/<RKEY>
 // - at://<DID>/app.bsky.feed.post/<RKEY>
 func webUriToAT(uri string) string {
-	if strings.HasPrefix(uri, "https://bsky.app/profile/") {
-		parts := strings.Split(uri, "/")
-		return fmt.Sprintf("at://%s/app.bsky.feed.post/%s", parts[3], parts[5])
+	uriParts, err := parseURI(uri)
+	if err != nil {
+		return uri
 	}
-	return uri
+	return fmt.Sprintf("at://%s/app.bsky.feed.post/%s", uriParts.Repo, uriParts.Rkey)
 }
 
 type UriParts struct {


### PR DESCRIPTION
minor fix if the URL comes from an external source (e.g. webhook) and you need to read the full contents (e.g. embeds for URIs etc.). Also exposes `search` in `call` for debugging purposes (it is intentionally not declared in the tool list).

follow up to #60 