### PR TITLE
feat(perplexity): add sonar-deep-research model support

### DIFF
--- a/servlets/perplexity-sonar/src/main.ts
+++ b/servlets/perplexity-sonar/src/main.ts
@@ -188,7 +188,7 @@ export function describeImpl(): ListToolsResult {
           model: {
             type: "string",
             description:
-              "The name of the model to use (e.g. 'sonar', 'sonar-pro', 'sonar-reasoning')",
+              "The name of the model to use (e.g. 'sonar', 'sonar-pro', 'sonar-reasoning', 'sonar-deep-research')"
           },
           messages: {
             type: "array",


### PR DESCRIPTION
# Add sonar-deep-research model support

## Description
Added support for Perplexity's sonar-deep-research model by updating the model description in the schema.

## Changes
- Updated model description to include sonar-deep-research as an available option
- Maintained flexibility for future model additions by avoiding hard-coded model lists

## Testing
- [x] Verified model description update
- [x] Tested with sonar-deep-research model request

## Documentation
- Updated model options in the schema description